### PR TITLE
added the tablet client category to disco identities

### DIFF
--- a/disco-categories.xml
+++ b/disco-categories.xml
@@ -10,6 +10,12 @@
     &LEGALNOTICE;
     <overview>This is the official registry of values for the 'category' and 'type' attributes of the &lt;identity/&gt; element within the 'http://jabber.org/protocol/disco#info' namespace (see &xep0030;), as registered with the &REGISTRAR;.</overview>
     <revision>
+      <version>0.24</version>
+      <date>2016-07-28</date>
+      <initials>dg</initials>
+      <remark>Added the tablet client category</remark>
+    </revision>
+    <revision>
       <version>0.23</version>
       <date>2011-02-22</date>
       <initials>psa</initials>
@@ -267,6 +273,10 @@
       <name>sms</name>
       <desc>A client that is not actually using an instant messaging client; however, messages sent to this contact will be delivered as Short Message Service (SMS) messages</desc>
       <doc>N/A</doc>
+    </type>
+    <type>
+      <name>tablet</tablet>
+      <desc>A client running on a touchscreen device larger than a smartphone and without a physical keyboard permanently attached to it.</desc>
     </type>
     <type>
       <name>web</name>


### PR DESCRIPTION
I would like to add a new type 'tablet' to the existing category 'client' of the service discovery identities. While XEP-0030 describes how to add new identities it doesn't describe how to add a new type to an existing identity.
