### PR TITLE
Features: Add Entity Capabilities to the stream features registry

### DIFF
--- a/stream-features.xml
+++ b/stream-features.xml
@@ -10,6 +10,12 @@
     &LEGALNOTICE;
     <overview>This is the official registry of XML stream features as maintained by the &REGISTRAR;. This registry contains only stream features that are defined in the <link url='/specs/'>XMPP RFCs</link> (published by the <link url='http://www.ietf.org/'>IETF</link>) or in <link url='/extensions/'>XMPP Extension Protocols</link> that have advanced to a status of Active, Draft, or Final within the standards process of the <link url='/xsf/'>XMPP Standards Foundation</link>. Other stream features may be in use within the Jabber/XMPP community, but are not added to this page until the relevant document meets the above criteria.</overview>
     <revision>
+      <version>0.8</version>
+      <date>2016-10-06</date>
+      <initials>egp</initials>
+      <remark>Added http://jabber.org/protocol/caps from XEP-0115.</remark>
+    </revision>
+    <revision>
       <version>0.7</version>
       <date>2013-09-26</date>
       <initials>psa</initials>
@@ -128,5 +134,12 @@
     <name>sm</name>
     <element>sm</element>
     <doc>&xep0198;</doc>
+  </feature>
+  <feature>
+    <ns>http://jabber.org/protocol/caps</ns>
+    <desc>Hash of Server Capabilities</desc>
+    <name>Entity Capabilities</name>
+    <element>c</element>
+    <doc>&xep0115;</doc>
   </feature>
 </registry>


### PR DESCRIPTION
The XEP itself was lacking such a section, which has been added in https://github.com/xsf/xeps/pull/257
