### PR TITLE
Allow overview to contain links

### DIFF
--- a/vars.dtd
+++ b/vars.dtd
@@ -4,7 +4,7 @@
 <!ELEMENT meta ( title, legal, overview, revision+ ) >
 <!ELEMENT title (#PCDATA)* >
 <!ELEMENT legal (#PCDATA)* >
-<!ELEMENT overview (#PCDATA)* >
+<!ELEMENT overview (#PCDATA, link)* >
 <!ELEMENT revision ( version, date, initials, remark ) >
 <!ELEMENT version (#PCDATA)* >
 <!ELEMENT date (#PCDATA)* >


### PR DESCRIPTION
The disco features registry currently has a `<link/>` element in the overview which is causing validation of the document to fail. Added it to the DTD. Someone who actually knows how XML works should probably validate that this makes sense; Vim isn't complaining about the document anymore, so I assume it's right, but I have no idea.

Alternatively, maybe we need to just remove the link where it's used?