### PR TITLE
Add proposed state to disco-features entries

### DIFF
--- a/disco-features.xml
+++ b/disco-features.xml
@@ -324,8 +324,9 @@
   </var>
   <var>
     <name>http://jabber.org/protocol/physloc</name>
-    <desc>DEPRECATED</desc>
+    <desc>See XEP-0080</desc>
     <doc>&xep0080;</doc>
+    <status>deprecated</status>
   </var>
   <var>
     <name>http://jabber.org/protocol/pubsub#access-authorize</name>
@@ -619,7 +620,8 @@
   <var>
     <name>jabber:iq:browse</name>
     <desc>See XEP-0011</desc>
-    <doc>&xep0011; (DEPRECATED)</doc>
+    <doc>&xep0011;</doc>
+    <status>deprecated</status>
   </var>
   <var>
     <name>jabber:iq:gateway</name>
@@ -639,7 +641,8 @@
   <var>
     <name>jabber:iq:pass</name>
     <desc>See XEP-0003</desc>
-    <doc>&xep0003; (DEPRECATED)</doc>
+    <doc>&xep0003;</doc>
+    <status>deprecated</status>
   </var>
   <var>
     <name>jabber:iq:privacy</name>
@@ -673,8 +676,9 @@
   </var>
   <var>
     <name>jabber:iq:time</name>
-    <desc>DEPRECATED</desc>
+    <desc>See XEP-0202</desc>
     <doc>&xep0202;</doc>
+    <status>deprecated</status>
   </var>
   <var>
     <name>jabber:iq:version</name>
@@ -693,8 +697,9 @@
   </var>
   <var>
     <name>jabber:x:delay</name>
-    <desc>DEPRECATED</desc>
+    <desc>See XEP-0203</desc>
     <doc>&xep0203;</doc>
+    <status>deprecated</status>
   </var>
   <var>
     <name>jabber:x:encrypted</name>
@@ -704,12 +709,14 @@
   <var>
     <name>jabber:x:event</name>
     <desc>See XEP-0022</desc>
-    <doc>&xep0022; (DEPRECATED)</doc>
+    <doc>&xep0022;</doc>
+    <status>deprecated</status>
   </var>
   <var>
     <name>jabber:x:expire</name>
     <desc>See XEP-0023</desc>
-    <doc>&xep0023; (DEPRECATED)</doc>
+    <doc>&xep0023;</doc>
+    <status>deprecated</status>
   </var>
   <var>
     <name>jabber:x:oob</name>
@@ -719,7 +726,8 @@
   <var>
     <name>jabber:x:roster</name>
     <desc>See XEP-0093</desc>
-    <doc>&xep0093; (DEPRECATED)</doc>
+    <doc>&xep0093;</doc>
+    <status>deprecated</status>
   </var>
   <var>
     <name>jabber:x:signed</name>

--- a/vars-xml.xsl
+++ b/vars-xml.xsl
@@ -14,6 +14,7 @@
       <name><xsl:value-of select='name'/></name>
       <desc><xsl:value-of select='desc'/></desc>
       <doc><xsl:value-of select='doc'/></doc>
+      <xsl:if test="status"><status><xsl:value-of select='status'/></status></xsl:if>
     </var>
   </xsl:template>
 

--- a/vars.dtd
+++ b/vars.dtd
@@ -10,9 +10,10 @@
 <!ELEMENT date (#PCDATA)* >
 <!ELEMENT initials (#PCDATA)* >
 <!ELEMENT remark (#PCDATA)* >
-<!ELEMENT var ( name, desc, doc ) >
+<!ELEMENT var ( name, desc, doc, status? ) >
 <!ELEMENT name (#PCDATA)* >
 <!ELEMENT desc (#PCDATA)* >
 <!ELEMENT doc (#PCDATA | link)* >
 <!ELEMENT link (#PCDATA)* >
 <!ATTLIST link url CDATA '' >
+<!ELEMENT status (#PCDATA)* >

--- a/vars.xsl
+++ b/vars.xsl
@@ -26,8 +26,19 @@
             <th>Description</th>
             <th>Documentation</th>
           </tr>
-          <xsl:apply-templates select='/registry/var'/>
+          <xsl:apply-templates select='/registry/var[not(status = "proposed")]'/>
         </table>
+        <xsl:if test='count(/registry/var[status = "proposed"]) &gt; 0'>
+          <h3>Proposed Features</h3>
+          <table border='1' cellpadding='3' cellspacing='0'>
+            <tr class='body'>
+              <th>Name</th>
+              <th>Description</th>
+              <th>Documentation</th>
+            </tr>
+            <xsl:apply-templates select='/registry/var[status = "proposed"]'/>
+          </table>
+        </xsl:if>
         <hr />
         <h2>Revision History</h2>
           <blockquote>

--- a/vars.xsl
+++ b/vars.xsl
@@ -26,7 +26,7 @@
             <th>Description</th>
             <th>Documentation</th>
           </tr>
-          <xsl:apply-templates select='/registry/var[not(status = "proposed")]'/>
+          <xsl:apply-templates select='/registry/var[status = "standard" or not(status)]'/>
         </table>
         <xsl:if test='count(/registry/var[status = "proposed"]) &gt; 0'>
           <h3>Proposed Features</h3>
@@ -37,6 +37,17 @@
               <th>Documentation</th>
             </tr>
             <xsl:apply-templates select='/registry/var[status = "proposed"]'/>
+          </table>
+        </xsl:if>
+        <xsl:if test='count(/registry/var[status = "deprecated"]) &gt; 0'>
+          <h3>Deprecated Features</h3>
+          <table border='1' cellpadding='3' cellspacing='0'>
+            <tr class='body'>
+              <th>Name</th>
+              <th>Description</th>
+              <th>Documentation</th>
+            </tr>
+            <xsl:apply-templates select='/registry/var[status = "deprecated"]'/>
           </table>
         </xsl:if>
         <hr />


### PR DESCRIPTION
[XEP-0053](https://xmpp.org/extensions/xep-0053.html) says that new experimental XEPs can have their registry entries added in a proposed state, but we currently don't have a proposed state.

Is something like this a good way to do it, or does this make any sense at all? Is there a way to do this for all registries, or would we have to add something like this for each individually?