### PR TITLE
Add link element declaration to disco-features DTD

### DIFF
--- a/vars.dtd
+++ b/vars.dtd
@@ -14,3 +14,5 @@
 <!ELEMENT name (#PCDATA)* >
 <!ELEMENT desc (#PCDATA)* >
 <!ELEMENT doc (#PCDATA)* >
+<!ELEMENT link (#PCDATA)* >
+<!ATTLIST link url CDATA '' >


### PR DESCRIPTION
A quick DTD fix. This probably needs to be done for the other DTD's as well; maybe it's worth making a "common" DTD eventually. For now I'm just fixing it here because I was working on this file and want Vim to stop complaining that things are broken.